### PR TITLE
Improved animation of togglers

### DIFF
--- a/js/drawer.js
+++ b/js/drawer.js
@@ -171,6 +171,21 @@ angular.module('ionic.contrib.drawer', ['ionic'])
   this.setState = function(value) {
     drawerState = value;
   };
+
+  this.animateAnimated = function($scope, status){
+    var elements = document.getElementsByClassName("animate");
+    for (var e = 0; e<elements.length; e++){
+      var el = elements[e];
+      if (el.className.indexOf("drawerToggle") > -1){
+         if(status === "open") {
+            el.style.transform = el.style.webkitTransform = 'translate3d(' + -5 + 'px, 0, 0)';
+          } else {
+            el.style.transform = el.style.webkitTransform = 'translate3d(' + 0 + 'px, 0, 0)';
+          }
+      }
+      
+    }
+  };
 }])
 
 .directive('drawer', ['$rootScope', '$ionicGesture', function($rootScope, $ionicGesture) {
@@ -219,23 +234,16 @@ angular.module('ionic.contrib.drawer', ['ionic'])
 .directive('drawerToggle', function() {
   return {
     restrict: 'A',
-    link: function($scope, $element, $attrs) {
+    controller: 'drawerCtrl',
+    link: function($scope, $element, $attrs, ctrl) {
       var el = $element[0];
       if($attrs.animate === "true") {
         $element.addClass('animate drawerToggle');
       }
       
       $element.bind('click', function(){
-        if($attrs.animate === "true") {
-          if($scope.toggleDrawer() === "open") {
-            el.style.transform = el.style.webkitTransform = 'translate3d(' + -5 + 'px, 0, 0)';
-          } else {
-            el.style.transform = el.style.webkitTransform = 'translate3d(' + 0 + 'px, 0, 0)';
-          }   
-        } else {
-            $scope.toggleDrawer();
-        }
-      });
+          ctrl.animateAnimated($scope, $scope.toggleDrawer());
+       });
     }
   };
 })

--- a/js/drawer.js
+++ b/js/drawer.js
@@ -172,7 +172,7 @@ angular.module('ionic.contrib.drawer', ['ionic'])
     drawerState = value;
   };
 
-  this.animateAnimated = function($scope, status){
+  this.animateTogglers = function($scope, status){
     var elements = document.getElementsByClassName("animate");
     for (var e = 0; e<elements.length; e++){
       var el = elements[e];
@@ -242,7 +242,7 @@ angular.module('ionic.contrib.drawer', ['ionic'])
       }
       
       $element.bind('click', function(){
-          ctrl.animateAnimated($scope, $scope.toggleDrawer());
+          ctrl.animateTogglers($scope, $scope.toggleDrawer());
        });
     }
   };


### PR DESCRIPTION
In order to use the _drawerToggle_ directive within other elements than the nav-bar button, I improved it so that no matter which element with the **drawer-toggle** attribute you clicked in, every element with both **drawer-toggle** and **animate=true** attributes will be animated.

Use Case: when clicking one of the drawer items with the **drawer-toggle** attribute, the nav-bar button that toggled it in the first time should be animated back to the closed position.
